### PR TITLE
add fromfd and new tests, optimize sockets using avalible C-API

### DIFF
--- a/tests/test_wepoll_cyares.py
+++ b/tests/test_wepoll_cyares.py
@@ -1,0 +1,44 @@
+from cyares import Channel
+from cyares.channel import CYARES_SOCKET_BAD
+from wepoll import EpollSelector
+from wepoll import epoll, EPOLLIN, EPOLLOUT
+from socket import AF_INET
+READ = EPOLLIN
+WRITE = EPOLLOUT
+
+# based off pycares's testsuite
+
+class TestCyaresWepoll:
+    channel: Channel
+    def wait(self):
+        # The function were really testing is this wait function
+        poll = epoll()
+        while True:
+            r, w = self.channel.getsock()
+            if not r and not w:
+                break
+            for rs in r:
+                poll.register(rs, EPOLLIN)
+            for ws in w:
+                poll.register(ws, EPOLLOUT)
+
+            timeout = self.channel.timeout()
+            if timeout == 0.0:
+                self.channel.process_fd(
+                    CYARES_SOCKET_BAD, CYARES_SOCKET_BAD
+                )
+                continue
+            for fd, event in poll.poll(timeout):
+                if event & ~EPOLLIN:
+                    self.channel.process_write_fd(fd)
+                if event & ~EPOLLOUT:
+                    self.channel.process_read_fd(fd)
+
+    def test_resolve(self):
+        self.channel = Channel(event_thread=False, servers=["8.8.8.8", "8.8.4.4"])
+        fut = self.channel.gethostbyname("python.org", AF_INET)
+        self.wait()
+        self.channel.cancel()
+        assert fut.result()
+
+

--- a/wepoll/__init__.py
+++ b/wepoll/__init__.py
@@ -1,6 +1,4 @@
 from ._wepoll import epoll
-from .loop import WepollEventLoop
-from .selector import EpollSelector
 from .flags import EPOLLERR as EPOLLERR
 from .flags import EPOLLHUP as EPOLLHUP
 from .flags import EPOLLIN as EPOLLIN
@@ -13,7 +11,8 @@ from .flags import EPOLLRDHUP as EPOLLRDHUP
 from .flags import EPOLLRDNORM as EPOLLRDNORM
 from .flags import EPOLLWRBAND as EPOLLWRBAND
 from .flags import EPOLLWRNORM as EPOLLWRNORM
-
+from .loop import WepollEventLoop
+from .selector import EpollSelector
 
 __author__ = "Vizonex"
 __version__ = "0.1.1"
@@ -34,4 +33,3 @@ __all__ = (
     "EpollSelector",
     "WepollEventLoop",
 )
-

--- a/wepoll/loop.py
+++ b/wepoll/loop.py
@@ -1,8 +1,13 @@
 from asyncio.selector_events import BaseSelectorEventLoop
+
 from .selector import EpollSelector
 
+
 class WepollEventLoop(BaseSelectorEventLoop):
+    """
+    Selector event loop for wepoll.
+
+    See `events.EventLoop <https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.EventLoop>`__ for API specification.
+    """
     def __init__(self):
         super().__init__(EpollSelector())
-
-

--- a/wepoll/selector.py
+++ b/wepoll/selector.py
@@ -1,10 +1,10 @@
 import math
+import sys
 from selectors import _PollLikeSelector as PollLikeSelector
 from typing import TYPE_CHECKING, Optional
 
 from ._wepoll import epoll
 from .flags import EPOLLIN, EPOLLOUT
-import sys
 
 # Added here if you didn't want to grab from somewhere else
 EVENT_READ = 1  # (1 << 0)
@@ -31,6 +31,7 @@ class EpollSelector(PollLikeSelector):
             _fd_to_key: "dict[int, SelectorKey]"
 
     if sys.version_info < (3, 13):
+
         def select(self, timeout=None):
             # This is shared between poll() and epoll().
             # epoll() has a different signature and handling of timeout parameter.
@@ -59,6 +60,7 @@ class EpollSelector(PollLikeSelector):
                     ready.append((key, events & key.events))
             return ready
     else:
+
         def select(self, timeout=None):
             if timeout is None:
                 timeout = -1
@@ -66,7 +68,7 @@ class EpollSelector(PollLikeSelector):
                 timeout = 0
             else:
                 pass
-            
+
             # epoll_wait() expects `maxevents` to be greater than zero;
             # we want to make sure that `select()` can be called when no
             # FD is registered.
@@ -82,7 +84,8 @@ class EpollSelector(PollLikeSelector):
             for fd, event in fd_event_list:
                 key = fd_to_key.get(fd)
                 if key:
-                    events = ((event & _NOT_EPOLLIN and EVENT_WRITE)
-                              | (event & _NOT_EPOLLOUT and EVENT_READ))
+                    events = (event & _NOT_EPOLLIN and EVENT_WRITE) | (
+                        event & _NOT_EPOLLOUT and EVENT_READ
+                    )
                     ready.append((key, events & key.events))
             return ready


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These Changes Add the following features
- `epoll.fromfd` experiemenal but has to recast to a handle from an integer
- socket file descriptors are now obtained via CPython's secret `_socket.C_API` for a bit of speed.
- New tests for __cyares__ for using epolls 

## Are there changes in behavior for the user?

There shouldn't be anything major changed except for the newer `fromfd` function and using more of the internally exposed data from CPython. 

## Is it a substantial burden for the maintainers to support this?

Nope. In fact this should be able to live for more than a decade unless the wepoll C Library introduces anything new.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
