### PR TITLE
make epolls threadsafe by sticking socket-CAPI inside the class object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "wepoll"
 description = "Cython adaptation of the wepoll C Library providing epoll selectors to windows"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
     { name = "Vizonex", email = "VizonexBusiness@gmail.com" }
 ]

--- a/wepoll/_wepoll.pxd
+++ b/wepoll/_wepoll.pxd
@@ -1,4 +1,5 @@
 from .wepoll cimport *
+from .socket cimport PySocketModule_APIObject
 
 
 # NOTE: Many portions of code can be externally 
@@ -7,7 +8,10 @@ cdef class epoll:
     cdef:
         HANDLE handle
         readonly bint closed
+        # Attempts to make socketmodule threadsafe during use...
+        PySocketModule_APIObject* socket_api
 
+    cdef SOCKET _fd_from_object(self, object obj) except -1
     cdef int _create(self, int sizehint)
     cdef int _create1(self)
     cdef int _close(self)

--- a/wepoll/socket.pxd
+++ b/wepoll/socket.pxd
@@ -1,5 +1,5 @@
 from cpython.object cimport PyObject, PyTypeObject
-from cpython.time cimport PyTime_AsSecondsDouble, PyTime_t
+from cpython.time cimport PyTime_t
 from libc.stdint cimport uintptr_t
 
 # After carefully observing socketmodule.h over from CPython and some 
@@ -53,12 +53,18 @@ typedef struct  {
 
 PySocketModule_APIObject* __cython_socket_api;
 
+/* Attempts to make pywepoll threadsafe */
+PySocketModule_APIObject* cimport_socket(){
+    return (PySocketModule_APIObject*)PyCapsule_Import(PySocket_CAPSULE_NAME, 0);
+}
+
 int import_socket(){
     /* PySocketModule_ImportModuleAndAPI Macro was not required 
      * we need the import to block incase of failure */ 
     __cython_socket_api = PyCapsule_Import(PySocket_CAPSULE_NAME, 0);
     return __cython_socket_api != NULL;
 }
+
 
 static inline int SocketType_CheckExact(PyObject* obj) {
     if (__cython_socket_api != NULL){
@@ -101,6 +107,8 @@ static inline int Socket_GetFileDescriptor(PyObject* sock, uintptr_t *fd){
     
     int Socket_GetFileDescriptor(object sock, uintptr_t *fd)
 
+    # Global
+    PySocketModule_APIObject* __cython_socket_api 
 
     ctypedef class _socket.socket [object PySocketSockObject, check_size ignore]:
         cdef:
@@ -133,3 +141,5 @@ static inline int Socket_GetFileDescriptor(PyObject* sock, uintptr_t *fd){
     # - 0 if False
     # - 1 if True 
     # - -1 if object is NULL
+
+    PySocketModule_APIObject* cimport_socket() except NULL


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Sticks sockmodule's secret CAPI into the epoll class to make everything threadsafe on the assumption that the CAPI Capsule is memory safe and will not leak memory.

## Are there changes in behavior for the user?

Users should have a better experience alone with one less things being unsafe for threads to use. 

## Is it a substantial burden for the maintainers to support this?

Nope. The only burden will be cleaning up afterwards and seeing if the C Library is threadsafe or needs additional edits to make itself threadsafe.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
